### PR TITLE
dapps browser

### DIFF
--- a/server/choco.sql
+++ b/server/choco.sql
@@ -50,3 +50,10 @@ CREATE VIEW votes AS
   FROM messages
   WHERE app = 'vote'
   ORDER BY unit_creation_date DESC;
+
+CREATE TABLE doc_urls (
+  unit VARCHAR(44),
+  source JSONB,
+  fetch_date TIMESTAMP,
+  PRIMARY KEY(unit)
+);

--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -19,6 +19,9 @@
         <router-link :to="'/@' + message.unit_authors[0]">
           <span>{{message.unit_authors[0] | name('', message.unit_authors[0])}}</span>
         </router-link>
+        <span v-if="getVerifiedStatus(message.unit_authors[0])" class="tooltipped tooltipped-n ml-1" aria-label="Verified">
+          <span class="octicon octicon-verified mb-1"></span>
+        </span>
         <span class="Label Label--outline ml-2">
           {{message.app}}
         </span>
@@ -50,6 +53,9 @@ import utils from '@/helpers/utils';
 
 export default {
   props: ['message'],
+  methods: {
+    getVerifiedStatus: (address) => utils.getVerifiedStatus(address)
+  },
   computed: {
     filteredOutputs: function () {
       let unitAuthors = this.message.unit_authors;

--- a/src/components/Message/Attestation.vue
+++ b/src/components/Message/Attestation.vue
@@ -5,6 +5,9 @@
       <router-link :to="'/@' + message.payload.address">
         <span>{{message.payload.address}}</span>
       </router-link>
+      <span v-if="getVerifiedStatus(message.payload.address)" class="tooltipped tooltipped-n ml-1" aria-label="Verified">
+        <span class="octicon octicon-verified mb-1"></span>
+      </span>
     </p>
     <ul class="Box Box--condensed d-inline-block w-100">
       <li class="Box-row" v-for="(field, index) in Object.keys(message.payload.profile)" :key="index">
@@ -18,7 +21,12 @@
 </template>
 
 <script>
+import utils from '@/helpers/utils';
+
 export default {
   props: ['message'],
+  methods: {
+    getVerifiedStatus: (address) => utils.getVerifiedStatus(address),
+  },
 }
 </script>

--- a/src/components/Message/Text.vue
+++ b/src/components/Message/Text.vue
@@ -1,6 +1,6 @@
 <template>
   <Markdown v-if="$route.name === 'unit'" :text="message.payload"/>
-  <Markdown :text="message.payload | truncate(1000)" v-else/>
+  <Markdown v-else :text="message.payload | truncate(1000)"/>
 </template>
 
 <script>

--- a/src/components/Profile/Hero.vue
+++ b/src/components/Profile/Hero.vue
@@ -14,11 +14,9 @@
       </div>
       <h2>
         {{profile.name || getAddressName(address) || obyteUsername || 'Undefined'}}
-        <router-link v-if="attestations.messages && attestations.messages.length" :to="'/@' + address + '/attestations'">
-          <span class="tooltipped tooltipped-n" aria-label="Verified">
-            <span class="octicon octicon-verified mb-1"></span>
-          </span>
-        </router-link>
+        <span v-if="getVerifiedStatus(address)" class="tooltipped tooltipped-n" aria-label="Verified">
+          <span class="octicon octicon-verified mb-1"></span>
+        </span>
       </h2>
       <div class="mb-1">
         <!--<span class="octicon octicon-zap mr-1"></span>-->
@@ -103,6 +101,7 @@ export default {
     }
   },
   methods: {
+    getVerifiedStatus: (address) => utils.getVerifiedStatus(address),
     getAddressName: (address) => utils.getAddressName(address),
     ...mapActions([
       'getProfile',

--- a/src/components/TopNav.vue
+++ b/src/components/TopNav.vue
@@ -13,31 +13,13 @@
         <router-link to="/assets">Assets</router-link>
         <router-link to="/attestors">Attestors</router-link>
         <router-link to="/oracles">Oracles</router-link>
-        <router-link to="/bots">Bots</router-link>
+        <router-link to="/dapps">dApps</router-link>
+        <router-link to="/bots">Chatbots</router-link>
         <router-link to="/witnesses">Witnesses</router-link>
         <router-link to="/polls">Polls</router-link>
         <router-link to="/timeline">Timeline</router-link>
       </div>
       <div id="menu-profile">
-        <!--
-        <div v-if="!app.address">
-          <span v-if="!app.rate.price_usd" class="octicon octicon-primitive-dot anim-pulse pr-0"></span>
-          <a
-            v-if="app.rate.price_usd"
-            class="pr-0"
-            href="https://bittrex.com/Market/Index?MarketName=BTC-GBYTE"
-            target="_blank"
-            rel="noopener"
-          >
-            <span class="octicon octicon-graph"></span>
-            1 GB =
-            <span>
-              ${{ parseFloat(app.rate.price_usd).toFixed(0) }}
-              ({{ parseFloat(app.rate.price_btc).toFixed(3) }} BTC)
-            </span>
-          </a>
-        </div>
-        -->
         <div v-if="!app.address">
           <router-link to="/about">About</router-link>
           <router-link to="/create">Get started</router-link>
@@ -58,6 +40,25 @@
             <span class="octicon octicon-gear f3"></span>
           </router-link>
         </div>
+        <!--
+        <div v-if="!app.address">
+          <span v-if="!app.rate.USD.price" class="octicon octicon-primitive-dot anim-pulse pr-0"></span>
+          <a
+            v-if="app.rate.USD.price"
+            class="pr-0"
+            href="https://coinpaprika.com/coin/gbyte-obyte/#!exchanges"
+            target="_blank"
+            rel="noopener"
+          >
+            <span class="octicon octicon-graph"></span>
+            1 GB =
+            <span>
+              ${{ parseFloat(app.rate.USD.price).toFixed(2) }}
+              ({{ parseFloat(app.rate.BTC.price).toFixed(4) }} BTC)
+            </span>
+          </a>
+        </div>
+        -->
       </div>
     </div>
   </div>

--- a/src/helpers/names.json
+++ b/src/helpers/names.json
@@ -178,5 +178,14 @@
     "profile": {
       "oracle_name": "PolloPollo oracle"
     }
+  },
+  {
+    "address": "FZP4ZJBMS57LYL76S3J75OJYXGTFAIBL"
+  },
+  {
+    "address": "3Y24IXW57546PQAPQ2SXYEPEDNX4KC6Y"
+  },
+  {
+    "address": "TZNMILIDIGD7YNKU25UZN2OVSRERQWNP"
   }
 ]

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -59,6 +59,17 @@ const getBalances = (unspent) => {
   return balances;
 };
 
+const getVerifiedStatus = (address) => {
+  let status = false
+  names.forEach(attestation => {
+    if (attestation.address === address) {
+      status = true;
+      return;
+    }
+  });
+  return status;
+};
+
 const getAddressName = (address, type, fallback) => {
   let profile = {};
   names.forEach(attestation => {
@@ -72,6 +83,9 @@ const getAddressName = (address, type, fallback) => {
 };
 
 const textOrJSON = (json) => {
+  if (parseFloat(json) == json) {
+    return json.toString();
+  }
   if (typeof json == 'string' && json.length < 1000) {
     try {
       json = JSON.parse(json);
@@ -86,6 +100,7 @@ export default {
   isSeedValid,
   getUnspent,
   getBalances,
+  getVerifiedStatus,
   getAddressName,
   textOrJSON,
 };

--- a/src/router.js
+++ b/src/router.js
@@ -8,6 +8,7 @@ import Unit from '@/views/Unit';
 import About from '@/views/About';
 import Attestors from '@/views/Attestors';
 import Oracles from '@/views/Oracles';
+import Dapps from '@/views/Dapps';
 import Bots from '@/views/Bots';
 import Witnesses from '@/views/Witnesses';
 import Polls from '@/views/Polls';
@@ -69,7 +70,8 @@ const router = new Router({
     { path: '/assets', name: 'assets', component: Assets, meta: { title: 'Assets' } },
     { path: '/attestors', name: 'attestors', component: Attestors, meta: { title: 'Attestors' } },
     { path: '/oracles', name: 'oracles', component: Oracles, meta: { title: 'Oracles' } },
-    { path: '/bots', name: 'bots', component: Bots, meta: { title: 'Bots' } },
+    { path: '/dapps', name: 'dapps', component: Dapps, meta: { title: 'dApps' } },
+    { path: '/bots', name: 'bots', component: Bots, meta: { title: 'Chatbots' } },
     { path: '/witnesses', name: 'witnesses', component: Witnesses, meta: { title: 'Witnesses' } },
     { path: '/login', name: 'login', component: Login, meta: { title: 'Log in' } },
     { path: '/create', name: 'create', component: Create, meta: { title: 'Create new account' } },

--- a/src/store/modules/app.js
+++ b/src/store/modules/app.js
@@ -22,6 +22,7 @@ const state = {
   witnesses: [],
   attestors: [],
   oracles: [],
+  dapps: [],
   assets: [],
   bots: [],
   path: null,
@@ -71,6 +72,9 @@ const mutations = {
   saveBots (state, bots) {
     state.bots = bots;
   },
+  saveDapps (state, dapps) {
+    state.dapps = dapps;
+  },
   saveAssets (state, assets) {
     state.assets = assets;
   },
@@ -88,9 +92,9 @@ const actions = {
     });
   },
   getRate: ({commit}) => {
-    axios.get('https://api.coinmarketcap.com/v1/ticker/obyte/').then(response => {
-      if (response.data && response.data[0] && response.data[0].price_btc) {
-        commit('saveRate', response.data[0]);
+    axios.get('https://api.coinpaprika.com/v1/tickers/gbyte-obyte?quotes=USD,BTC').then(response => {
+      if (response.data && response.data.quotes) {
+        commit('saveRate', response.data.quotes);
       }
     }).catch(err => console.log(err));
   },
@@ -182,6 +186,11 @@ const actions = {
   getBots: ({ commit }) => {
     client.api.getBots().then(bots => {
       commit('saveBots', bots);
+    });
+  },
+  getDapps: ({ commit }) => {
+    api.requestAsync('get_aa_metadata', null).then(dapps => {
+      commit('saveDapps', dapps);
     });
   },
   getAssets: ({ commit }) => {

--- a/src/styles.less
+++ b/src/styles.less
@@ -98,7 +98,7 @@ h1, h2, h3, h4, b, .btn {
 .container {
   max-width: 100%;
   @media screen and (max-width: 1024px) {
-    .column.one-third {
+    .column.one-third, .column.one-half {
       width: 100%;
     }
   }

--- a/src/views/Assets.vue
+++ b/src/views/Assets.vue
@@ -16,7 +16,7 @@
           class="form-control input-lg mb-2"
         />
       </div>
-      <span v-if="items.length === 0" class="octicon octicon-primitive-dot anim-pulse pr-0"></span>
+      <MessageBlank v-if="items.length === 0"/>
       <div class="columns overflow-hidden mb-5">
         <div
           v-for="(asset, index) in filteredList" :key="index"
@@ -44,7 +44,7 @@
           >
             <h3 class="mb-2">
               <a
-                href="https://obyte.app"
+                href="https://asset.obyte.app/"
                 target="_blank"
               >
                 Create your own asset
@@ -52,7 +52,7 @@
             </h3>
             <div class="mb-2">
               <a
-                href="https://obyte.app"
+                href="hhttps://asset.obyte.app/"
                 target="_blank"
                 class="btn btn-blue"
               >

--- a/src/views/Attestors.vue
+++ b/src/views/Attestors.vue
@@ -16,6 +16,9 @@
             <router-link :to="'/@' + attestor.unit_authors[0]" class="mr-1">
               <span>{{attestor.unit_authors[0]}}</span>
             </router-link>
+            <span v-if="getVerifiedStatus(attestor.unit_authors[0])" class="tooltipped tooltipped-n ml-1" aria-label="Verified">
+              <span class="octicon octicon-verified mb-1"></span>
+            </span>
           </div>
         </div>
         <div class="d-flex">
@@ -30,6 +33,7 @@
 </template>
 
 <script>
+import utils from '@/helpers/utils';
 import { mapActions } from 'vuex';
 
 export default {
@@ -38,9 +42,12 @@ export default {
       return this.$store.state.app.attestors || [];
     },
   },
-  methods: mapActions([
-   'getAttestors',
-  ]),
+  methods: {
+    getVerifiedStatus: (address) => utils.getVerifiedStatus(address),
+    ...mapActions([
+      'getAttestors',
+    ]),
+  },
   created() {
     if (this.$store.state.app.attestors.length === 0) {
       this.getAttestors();

--- a/src/views/Bots.vue
+++ b/src/views/Bots.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
     <div class="container-md py-8 p-responsive text-center">
-      <h1>Bots</h1>
+      <h1>Chatbots</h1>
       <p v-if="items.length != 0">
-        {{items.length}} bots available
+        {{items.length}} chatbots available
       </p>
     </div>
     <div class="container p-responsive">
@@ -16,7 +16,7 @@
           class="form-control input-lg mb-2"
         />
       </div>
-      <span v-if="items.length === 0" class="octicon octicon-primitive-dot anim-pulse pr-0"></span>
+      <MessageBlank v-if="items.length === 0"/>
       <div class="columns overflow-hidden mb-5">
         <div
           v-for="(bot, index) in filteredList" :key="index"
@@ -34,7 +34,7 @@
             <p class="mb-3">{{bot.description | truncate(100)}}</p>
             <div class="mb-2">
               <a :href="'obyte:' + bot.pairing_code" class="btn">
-                Add bot
+                Add chatbot
               </a>
             </div>
           </div>
@@ -46,7 +46,7 @@
           >
             <h3 class="mb-2">
               <a
-                href="https://github.com/byteball/ocore/wiki/Writing-chatbots-for-Byteball"
+                href="https://developer.obyte.org/"
                 target="_blank"
               >
                 Writing chatbots for Obyte
@@ -54,7 +54,7 @@
             </h3>
             <div class="mb-2">
               <a
-                href="https://github.com/byteball/ocore/wiki/Writing-chatbots-for-Byteball"
+                href="https://developer.obyte.org/"
                 target="_blank"
                 class="btn btn-blue"
               >

--- a/src/views/Dapps.vue
+++ b/src/views/Dapps.vue
@@ -52,9 +52,6 @@
                 Source code
               </a>
             </div>
-            <!--
-            <h6>Issuer: {{dapp.payload.issuer}}</h6>
-            -->
           </div>
         </div>
         <div v-if="items.length != 0" class="column one-half clearfix p-0">

--- a/src/views/Dapps.vue
+++ b/src/views/Dapps.vue
@@ -1,0 +1,122 @@
+<template>
+  <div>
+    <div class="container-md py-8 p-responsive text-center">
+      <h1>dApps (Autonomous Agents)</h1>
+      <p v-if="items.length != 0">
+        {{items.length}} dApps available
+      </p>
+    </div>
+    <div class="container p-responsive">
+      <div class="text-center mb-4">
+        <input
+          v-if="items.length != 0"
+          v-model="query"
+          type="text"
+          placeholder="Search"
+          class="form-control input-lg mb-2"
+        />
+      </div>
+      <MessageBlank v-if="items.length === 0"/>
+      <div class="columns overflow-hidden mb-5">
+        <div
+          v-for="(dapp, index) in filteredList" :key="index"
+          class="column one-half clearfix p-0"
+        >
+          <div
+            class="Box d-flex flex-column box-shadow m-2 p-4"
+            style="height: 400px;"
+          >
+            <h4 class="mb-2">
+              <router-link class="mb-3" :to="'/@' + dapp.payload.address">
+                <span>{{dapp.payload.address}}</span>
+              </router-link>
+              <span v-if="getVerifiedStatus(dapp.payload.address)" class="tooltipped tooltipped-n float-right" aria-label="Verified">
+                <span class="octicon octicon-verified mb-1"></span>
+              </span>
+            </h4>
+            <router-link class="mb-3" :to="'/u/' + dapp.unit">
+              <span>#{{dapp.unit | truncate(10)}}</span>
+              <span v-if="dapp.source.version" class="float-right">v{{dapp.source.version | truncate(10)}}</span>
+            </router-link>
+            <p v-if="dapp.source.description">{{dapp.source.description | truncate(1000)}}</p>
+            <div v-if="dapp.payload.definition[0] === 'autonomous agent'" class="mb-2">
+              <a :href="'obyte:' + dapp.payload.address" class="btn">
+                Interact with Autonomous Agent
+              </a>
+            </div>
+            <div v-if="dapp.source.homepage_url || dapp.source.source_url" class="mb-2">
+              <a v-if="dapp.source.homepage_url" :href="dapp.source.homepage_url | truncate(1000)" target="_blank" class="btn btn-blue mr-2">
+                Home page
+              </a>
+              <a v-if="dapp.source.source_url" :href="dapp.source.source_url | truncate(1000)" target="_blank" class="btn btn-blue">
+                Source code
+              </a>
+            </div>
+            <!--
+            <h6>Issuer: {{dapp.payload.issuer}}</h6>
+            -->
+          </div>
+        </div>
+        <div v-if="items.length != 0" class="column one-half clearfix p-0">
+          <div
+            class="Box d-flex flex-column box-shadow m-2 p-4"
+            style="height: 400px;"
+          >
+            <h3 class="mb-2">
+              <a
+                href="https://developer.obyte.org/autonomous-agents"
+                target="_blank"
+              >
+                Writing dApps on Obyte
+              </a>
+            </h3>
+            <div class="mb-2">
+              <a
+                href="https://developer.obyte.org/autonomous-agents"
+                target="_blank"
+                class="btn btn-blue"
+              >
+                Learn more
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import utils from '@/helpers/utils';
+import { mapActions } from 'vuex';
+
+export default {
+  data () {
+    return {
+      query: this.$route.query.q,
+    }
+  },
+  computed: {
+    items () {
+      return this.$store.state.app.dapps || [];
+    },
+    filteredList() {
+      return this.$store.state.app.dapps.filter(dapp => {
+        const query = this.query ? this.query.toLowerCase() : '';
+        return JSON.stringify(dapp).toLowerCase().includes(query);
+      })
+    }
+  },
+  methods: {
+    getVerifiedStatus: (address) => utils.getVerifiedStatus(address),
+    ...mapActions([
+      'getDapps',
+    ]),
+  },
+  created() {
+    if (this.$store.state.app.dapps.length === 0) {
+      this.getDapps();
+    }
+  }
+}
+</script>

--- a/src/views/Oracles.vue
+++ b/src/views/Oracles.vue
@@ -16,6 +16,9 @@
             <router-link :to="'/@' + oracle.unit_authors[0]" class="mr-1">
               <span>{{oracle.unit_authors[0]}}</span>
             </router-link>
+            <span v-if="getVerifiedStatus(oracle.unit_authors[0])" class="tooltipped tooltipped-n ml-1" aria-label="Verified">
+              <span class="octicon octicon-verified mb-1"></span>
+            </span>
           </div>
         </div>
         <div class="d-flex">
@@ -30,6 +33,7 @@
 </template>
 
 <script>
+import utils from '@/helpers/utils';
 import { mapActions } from 'vuex';
 
 export default {
@@ -38,9 +42,12 @@ export default {
       return this.$store.state.app.oracles || [];
     },
   },
-  methods: mapActions([
-   'getOracles',
-  ]),
+  methods: {
+    getVerifiedStatus: (address) => utils.getVerifiedStatus(address),
+    ...mapActions([
+      'getOracles',
+    ]),
+  },
   created() {
     if (this.$store.state.app.oracles.length === 0) {
       this.getOracles();

--- a/src/views/Witnesses.vue
+++ b/src/views/Witnesses.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="container-md p-responsive">
-      <h1 class="py-8 text-center">Witnesses</h1>
+      <h1 class="py-8 text-center">Witnesses (Order Providers)</h1>
     </div>
     <ul class="container-md p-responsive">
       <MessageLoading v-if="witnesses.length === 0"/>
@@ -16,6 +16,9 @@
             <router-link :to="'/@' + witness" class="mr-1">
               <span>{{witness}}</span>
             </router-link>
+            <span v-if="getVerifiedStatus(witness)" class="tooltipped tooltipped-n ml-1" aria-label="Verified">
+              <span class="octicon octicon-verified mb-1"></span>
+            </span>
           </div>
         </div>
         <div class="d-flex">
@@ -30,6 +33,7 @@
 </template>
 
 <script>
+import utils from '@/helpers/utils';
 import { mapActions } from 'vuex';
 
 export default {
@@ -38,9 +42,12 @@ export default {
       return this.$store.state.app.witnesses || [];
     },
   },
-  methods: mapActions([
-    'getWitnesses',
-  ]),
+  methods: {
+    getVerifiedStatus: (address) => utils.getVerifiedStatus(address),
+    ...mapActions([
+      'getWitnesses',
+    ]),
+  },
   created() {
     if (this.$store.state.app.witnesses.length === 0) {
       this.getWitnesses();


### PR DESCRIPTION
* added new table to store AA doc_url JSON content (didn't add to production database)
* fetching AA doc_url JSON content when unit becomes stable
* removed verified badge from any attestation, now only shows verified if in names.json
* added 3 addresses to names.json that add Verified badge, but doesn't override the name
* added verified badges to all pages, not just profile page
* limited the length of AA definition shown in feed, unit page shows full length
* fixed AA definitions that contained tabs and line changes
* added a page for dApps (Autonomous Agents) that have doc_url with JSON content
* replaced CoinMarketCap price API with CoinPaprika price API
* fixed textOrJSON from removing 0 decimals from the end of numbers
* fixed old Learn More links for Assets and Chatbots pages
* renamed Bots to Chatbots (more clear what they are)
* added /joint endpoint the possibility to fetch messages, if missing
